### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
       - develop
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   NEXTAUTH_SECRET: 'test'
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test?schema=public'


### PR DESCRIPTION
Potential fix for [https://github.com/ladal1/summerjob/security/code-scanning/8](https://github.com/ladal1/summerjob/security/code-scanning/8)

To fix the issue, we will add an explicit `permissions` block to the workflow. Since the workflow primarily involves linting and building code, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to access the repository's contents without granting write access. We will add this `permissions` block at the root level of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
