### PR TITLE
feat: add unregister restriction of 6-hours for adoration

### DIFF
--- a/web/lib/components/adoration/AdorationSlotsTable.tsx
+++ b/web/lib/components/adoration/AdorationSlotsTable.tsx
@@ -77,7 +77,7 @@ export default function AdorationSlotsTable({
     const now = new Date()
     const timeDiff = slotStartTime.getTime() - now.getTime()
     const sixHoursInMs = 6 * 60 * 60 * 1000 // 6 hours in milliseconds
-    return timeDiff > sixHoursInMs
+    return timeDiff >= sixHoursInMs
   }
 
   return (

--- a/web/lib/components/adoration/AdorationSlotsTable.tsx
+++ b/web/lib/components/adoration/AdorationSlotsTable.tsx
@@ -73,6 +73,13 @@ export default function AdorationSlotsTable({
     }
   }
 
+  const canUnregister = (slotStartTime: Date) => {
+    const now = new Date()
+    const timeDiff = slotStartTime.getTime() - now.getTime()
+    const sixHoursInMs = 6 * 60 * 60 * 1000 // 6 hours in milliseconds
+    return timeDiff > sixHoursInMs
+  }
+
   return (
     <div>
       <div className="mb-3">
@@ -113,32 +120,42 @@ export default function AdorationSlotsTable({
                 </td>
               </tr>
             )}
-            {slots.map(slot => (
-              <tr key={slot.id}>
-                <td>{format(slot.localDateStart, 'HH:mm')}</td>
-                <td>{slot.location}</td>
-                <td>{`${slot.workerCount} / ${slot.capacity}`}</td>
-                <td>
-                  {slot.isUserSignedUp ? (
-                    <button
-                      className="btn btn-sm btn-outline-danger"
-                      disabled={signuping === slot.id}
-                      onClick={() => handleLogout(slot.id)}
-                    >
-                      {signuping === slot.id ? 'Odhlašuji...' : 'Odhlásit se'}
-                    </button>
-                  ) : (
-                    <button
-                      className="btn btn-sm btn-primary"
-                      disabled={signuping === slot.id}
-                      onClick={() => handleSignup(slot.id)}
-                    >
-                      {signuping === slot.id ? 'Přihlašuji...' : 'Přihlásit se'}
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
+            {slots.map(slot => {
+              const canUnregisterFromSlot = canUnregister(slot.localDateStart)
+              return (
+                <tr key={slot.id}>
+                  <td>{format(slot.localDateStart, 'HH:mm')}</td>
+                  <td>{slot.location}</td>
+                  <td>{`${slot.workerCount} / ${slot.capacity}`}</td>
+                  <td>
+                    {slot.isUserSignedUp ? (
+                      canUnregisterFromSlot ? (
+                        <button
+                          className="btn btn-sm btn-outline-danger"
+                          disabled={signuping === slot.id}
+                          onClick={() => handleLogout(slot.id)}
+                        >
+                          {signuping === slot.id ? 'Odhlašuji...' : 'Odhlásit se'}
+                        </button>
+                      ) : (
+                        <span className="text-muted small">
+                          <i className="fas fa-lock me-1"></i>
+                          Nelze se odhlásit (méně než 6h do začátku)
+                        </span>
+                      )
+                    ) : (
+                      <button
+                        className="btn btn-sm btn-primary"
+                        disabled={signuping === slot.id}
+                        onClick={() => handleSignup(slot.id)}
+                      >
+                        {signuping === slot.id ? 'Přihlašuji...' : 'Přihlásit se'}
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       )}

--- a/web/pages/api/adoration/[id]/signup/index.ts
+++ b/web/pages/api/adoration/[id]/signup/index.ts
@@ -12,8 +12,6 @@ export default APIAccessController(
         session: ExtendedSession
     ) {
         const slotId = req.query.id as string
-        console.log('session:', session)
-        console.log('slotId:', slotId)
         if (!slotId || !session.userID) {
             return res.status(400).json({ message: 'Chybí slot nebo přihlášený uživatel.' })
         }


### PR DESCRIPTION
This pull request introduces a new feature to restrict users from unregistering from adoration slots less than six hours before the start time and removes unnecessary debugging logs from the API signup endpoint. Below are the key changes grouped by theme:

### Feature: Restricting Unregistration

* Added a helper function `canUnregister` in `AdorationSlotsTable` to determine if a user can unregister based on the slot's start time being more than six hours away.
* Updated the `slots.map` logic in `AdorationSlotsTable` to conditionally display either an "Unregister" button or a disabled message when unregistration is not allowed. [[1]](diffhunk://#diff-abd9ad20e4c065c4434f53befa6c3ae6431fafca1e38828df31a65c696d6fa8fL116-R145) [[2]](diffhunk://#diff-abd9ad20e4c065c4434f53befa6c3ae6431fafca1e38828df31a65c696d6fa8fL141-R158)

### Cleanup: Debugging Logs Removal

* Removed `console.log` statements for `session` and `slotId` in the API signup endpoint to clean up the code. ([web/pages/api/adoration/[id]/signup/index.tsL15-L16](diffhunk://#diff-750ec6c9c13710c223a070630042a73d66f779ae2079c3012d52e829b37db2a1L15-L16))