### PR TITLE
feat: Include worker phone numbers in Adoration management views

### DIFF
--- a/web/lib/components/adoration/AdorationAdminPage.tsx
+++ b/web/lib/components/adoration/AdorationAdminPage.tsx
@@ -233,7 +233,7 @@ export default function AdminAdorationManager({ event }: Props) {
                     {slot.workers.length > 0 ? (
                       slot.workers.map((w, i) => (
                         <span key={i}>
-                          {w.firstName} {w.lastName}
+                          {w.firstName} {w.lastName} ({w.phone})
                           {i < slot.workers.length - 1 ? ', ' : ''}
                         </span>
                       ))

--- a/web/lib/fetcher/adoration.ts
+++ b/web/lib/fetcher/adoration.ts
@@ -87,6 +87,7 @@ export function useAPIAdorationSlotsAdmin(date: string, eventId: string): {
         workers: slot.workers.map((w: any) => ({
           firstName: w.firstName,
           lastName: w.lastName,
+          phone: w.phone,
         })),
       }
     })

--- a/web/lib/types/adoration.ts
+++ b/web/lib/types/adoration.ts
@@ -22,5 +22,6 @@ export interface FrontendAdorationSlot {
   workers: {
     firstName: string
     lastName: string
+    phone: string
   }[]
 }


### PR DESCRIPTION
This pull request includes updates to improve the user experience in the adoration management and slots table components, as well as backend changes to support these enhancements. The most notable changes include displaying worker phone numbers, filtering adoration slots, and enhancing the table layout.

### Frontend Enhancements:

* **Display Worker Phone Numbers**:
  - Updated `AdorationAdminPage.tsx` to display the phone numbers of workers alongside their names in the admin view.
  - Extended the `FrontendAdorationSlot` type to include a `phone` field for workers.

* **Filter Adoration Slots**:
  - Modified `AdorationSlotsTable.tsx` to filter out full slots unless the user is signed up for them. This ensures users only see relevant slots.

* **Enhanced Table Layout**:
  - Added new columns to the adoration slots table for "End Time" and "Duration," and adjusted column widths for better readability. [[1]](diffhunk://#diff-abd9ad20e4c065c4434f53befa6c3ae6431fafca1e38828df31a65c696d6fa8fR88-R119) [[2]](diffhunk://#diff-abd9ad20e4c065c4434f53befa6c3ae6431fafca1e38828df31a65c696d6fa8fL141-R135)
  - Wrapped the table in a responsive container to improve usability on smaller screens.

### Backend Support:

* **Worker Phone Numbers in API**:
  - Updated the `useAPIAdorationSlotsAdmin` function to include the `phone` field in the worker data returned by the API.

### Code Cleanup:

* Removed the unused `apiAdorationLogout` function and its associated `handleLogout` logic from `AdorationSlotsTable.tsx`, simplifying the codebase. [[1]](diffhunk://#diff-abd9ad20e4c065c4434f53befa6c3ae6431fafca1e38828df31a65c696d6fa8fL7) [[2]](diffhunk://#diff-abd9ad20e4c065c4434f53befa6c3ae6431fafca1e38828df31a65c696d6fa8fL63-L75)