### PR TITLE
feat: Add Markdown rendering for job descriptions and style adjustments

### DIFF
--- a/web/app/(print)/print-plan/[id]/page.tsx
+++ b/web/app/(print)/print-plan/[id]/page.tsx
@@ -6,6 +6,8 @@ import { ActiveJobNoPlan } from 'lib/types/active-job'
 import Image from 'next/image'
 import logoImage from 'public/logo-smj-yellow.png'
 import React from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import '/styles/print.css'
 import { ToolCompleteData } from 'lib/types/tool'
 import { toolNameMapping } from 'lib/data/enumMapping/toolNameMapping'
@@ -74,9 +76,11 @@ function JobInfo({
       <div className="job-data-col">
         <div className="w-50">
           <h2>{job.proposedJob.name}</h2>
-          <p style={{ whiteSpace: 'pre-wrap' }}>
-            {job.proposedJob.publicDescription}
-          </p>
+          <div className="markdown-content">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {job.proposedJob.publicDescription}
+            </ReactMarkdown>
+          </div>
           <div className="mb-2" style={{ fontSize: '1.1em', fontWeight: 'bold', color: '#d63384' }}>
             <i className="fas fa-user-nurse me-1"></i>
             Zdravotník: 732 403 990

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -189,3 +189,118 @@ h2 {
 .text-break-word {
   word-break: break-word;
 }
+
+/* Markdown content styles for print */
+.markdown-content {
+  line-height: 1.6;
+}
+
+.markdown-content p {
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-content strong {
+  font-weight: 600;
+  color: inherit;
+}
+
+.markdown-content em {
+  font-style: italic;
+}
+
+.markdown-content u {
+  text-decoration: underline;
+}
+
+.markdown-content a {
+  color: #000;
+  text-decoration: underline;
+}
+
+.markdown-content a:hover {
+  color: #000;
+  text-decoration: none;
+}
+
+.markdown-content ul,
+.markdown-content ol {
+  margin-bottom: 0.5rem;
+  padding-left: 1.2rem;
+}
+
+.markdown-content ul li,
+.markdown-content ol li {
+  margin-bottom: 0.2rem;
+}
+
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+.markdown-content h1:first-child,
+.markdown-content h2:first-child,
+.markdown-content h3:first-child,
+.markdown-content h4:first-child,
+.markdown-content h5:first-child,
+.markdown-content h6:first-child {
+  margin-top: 0;
+}
+
+.markdown-content blockquote {
+  margin: 0.5rem 0;
+  padding: 0.25rem 0.5rem;
+  border-left: 2px solid #666;
+  background-color: #f5f5f5;
+  font-style: italic;
+}
+
+.markdown-content code {
+  background-color: #f1f1f1;
+  padding: 0.1rem 0.2rem;
+  border-radius: 2px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9em;
+}
+
+.markdown-content pre {
+  background-color: #f1f1f1;
+  padding: 0.5rem;
+  border-radius: 3px;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+  font-size: 0.85em;
+}
+
+.markdown-content pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+.markdown-content table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0.5rem 0;
+}
+
+.markdown-content table th,
+.markdown-content table td {
+  border: 1px solid #666;
+  padding: 0.2rem 0.3rem;
+  text-align: left;
+}
+
+.markdown-content table th {
+  background-color: #f1f1f1;
+  font-weight: 600;
+}


### PR DESCRIPTION
This pull request enhances the rendering of markdown content in the print view of the application by integrating a markdown parser and adding corresponding styles for print formatting. The most important changes include introducing `ReactMarkdown` with `remark-gfm` for rendering markdown, updating the `JobInfo` component to use this markdown renderer, and adding comprehensive CSS styles for markdown content.

### Markdown rendering integration:

* `web/app/(print)/print-plan/[id]/page.tsx`: Added `ReactMarkdown` and `remark-gfm` imports to enable markdown parsing and rendering. Updated the `JobInfo` component to replace the plain text rendering of `job.proposedJob.publicDescription` with `ReactMarkdown` for better markdown support. ([web/app/(print)/print-plan/[id]/page.tsxR9-R10](diffhunk://#diff-336ac876bbdd85a55ecf016ca7d1477a359ea5900a8bebb53f78266f99c73109R9-R10), [web/app/(print)/print-plan/[id]/page.tsxL77-R83](diffhunk://#diff-336ac876bbdd85a55ecf016ca7d1477a359ea5900a8bebb53f78266f99c73109L77-R83))

### Styling for markdown content:

* [`web/styles/print.css`](diffhunk://#diff-ceaaa146f3a32dba9932a3592734233a432dd6634bae0bccb4ee47cdab1189f4R192-R306): Introduced detailed CSS styles for various markdown elements (e.g., headings, lists, blockquotes, tables, etc.) to ensure proper formatting and readability in the print view.