### PR TITLE
fix: add session check in MyPlanPage to handle unauthenticated users

### DIFF
--- a/web/app/(web)/(user)/my-plan/page.tsx
+++ b/web/app/(web)/(user)/my-plan/page.tsx
@@ -16,8 +16,12 @@ export const dynamic = 'force-dynamic'
 
 export default async function MyPlanPage() {
   const session = await getSMJSession()
+  
+  if (!session) {
+    return <ErrorPage404 message="Uživatel není přihlášen." />
+  }
    
-  const userId = session!.userID
+  const userId = session.userID
   const worker = await getWorkerById(userId)
   if (!worker || !worker.availability) {
     return <ErrorPage404 message="Pracant nenalezen." />


### PR DESCRIPTION
This pull request introduces an error-handling improvement in the `MyPlanPage` component. The change ensures that if there is no active session, a user-friendly 404 error page is displayed instead of attempting to access properties on a potentially undefined session object.

Error handling improvement:

* [`web/app/(web)/(user)/my-plan/page.tsx`](diffhunk://#diff-44149d91708741237fd7aa3b0f739964b7287136beb95bdb6514f603b7c5473bL20-R24): Added a check to verify the existence of `session` before accessing its properties. If `session` is undefined, the component now renders an `ErrorPage404` with a message indicating the user is not logged in.